### PR TITLE
Implement 5-second phone retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ From your Terminal, just run
 ```bash
 bash run_pipeline.sh
 ```
+
+The pipeline keeps the bounding box of any person detected using a phone for
+five seconds even if the phone is not detected in subsequent frames.

--- a/pipeline.py
+++ b/pipeline.py
@@ -90,16 +90,21 @@ class MobilePhoneDetection:
             if not found:
                 self._mem.append({"id": tid, "bbox": box, "ts": now})
 
+        for mem in self._mem:
+            tid = mem["id"]
+            box = track_boxes.get(tid)
+            if box is not None:
+                mem["bbox"] = box
+
         self._mem = [m for m in self._mem if now - m["ts"] <= self.retention_secs]
 
         # 5. Drawing annotations
         annotated = None
         if draw:
             canvas = frame.copy()
-            for tid in phone_owner_ids:
-                box = track_boxes.get(tid)
-                if box is None:
-                    continue
+            for mem in self._mem:
+                tid = mem["id"]
+                box = mem["bbox"]
                 x1, y1, x2, y2 = box
                 cv2.rectangle(canvas, (x1, y1), (x2, y2), (255, 255, 0), 2)
                 cv2.putText(canvas, f"ID {tid} | Person", (x1, y1 - 6),


### PR DESCRIPTION
## Summary
- keep phone detection results in memory for 5 seconds
- show retained boxes when drawing frames
- document new behavior in README

## Testing
- `python -m py_compile pipeline.py`
- (failed to run video example due to missing heavy dependencies)

------
https://chatgpt.com/codex/tasks/task_e_6852226c3a088321832cace1517b1517